### PR TITLE
Throw helpful error message if class is initialized with non functions as methods.

### DIFF
--- a/lib/Joose/Managed/Class.js
+++ b/lib/Joose/Managed/Class.js
@@ -180,6 +180,9 @@ Joose.Managed.Class = new Joose.Proto.Class('Joose.Managed.Class', {
     
     
     addMethod: function (name, func, props) {
+        if (!(func instanceof Function)) {
+            throw new Error("Joose.Managed.Class:addMethod: Method declaration for " + name + " was not a function.")
+        }
         props = props || {}
         props.init = func
         


### PR DESCRIPTION
Example of previous behavior (nodejs):
    var Joose = require('Joose');
    Joose.Class("C", {
      methods : {
        foo : null
      }
    });
##     new C().foo();

```
node.js:63
    throw e;
    ^
TypeError: Cannot read property 'apply' of null
    at [object Object].foo (/Users/adam/.local/lib/node/.npm/joose/3.13.0/package/lib/Task/Joose/Core.js:752:13)
    at Object.<anonymous> (/Users/adam/mess/2010/42/triviabot/test.js:7:9)
    at Module._compile (node.js:462:23)
    at Module._loadScriptSync (node.js:469:10)
    at Module.loadSync (node.js:338:12)
    at Object.runMain (node.js:522:24)
    at Array.<anonymous> (node.js:755:12)
    at EventEmitter._tickCallback (node.js:55:22)
    at node.js:769:9
```
